### PR TITLE
Update ignore list and fixed call to Task Manager JXA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 Gemfile.lock
+.ruby-version
+.ruby-gemset

--- a/lib/task_sources/jira/jira_to_jxa_app.rb
+++ b/lib/task_sources/jira/jira_to_jxa_app.rb
@@ -165,7 +165,7 @@ class JiraToJxaApp
 
     begin
       puts "\nRunning #{JXA_FILE}"
-      things_jxa = File.join(File.dirname(__FILE__), 'task_destinations', JXA_FILE)
+      things_jxa = File.join(File.dirname(__FILE__), '../../task_destinations', JXA_FILE)
 
       output = `#{things_jxa} #{file.path}`
       output.split("\n").each do |line|


### PR DESCRIPTION
Moving jira_to_jxa_app.rb into a subdirectory was causing the call to the task manager to fail with this message.

    Error - No such file or directory - /Users/larry/dev/jiratotaskmanagers/lib/task_sources/jira/task_destinations/add_to_omnifocus.jxa

Adding '../../' fixed it. 

Two other improvements I didn't make but would consider:

1. There may be a way to set the file location to the project root (so you can move it again without breaking the call to the task manager specific JXA). I'm not sure how to do this one.
2. Looking at this commit I'd probably want to change the variable name from 'things_jxa' to 'taskmanager_jxa' to make it clearer. I'm using omnifocus and that variable name gave me pause. If you'd like I can clean that up and do give you another pull request.

The .gitignore addition was just for the rvm dotfiles I used.