### PR TITLE
Added support for non ASCII languages

### DIFF
--- a/lib/task_destinations/add_to_things.jxa
+++ b/lib/task_destinations/add_to_things.jxa
@@ -21,7 +21,7 @@ function run(input, params) {
 
 	var strPath = input[0]
 	if (VERBOSE) { 	console.log("Path:"+strPath) }
-	var nsjira_report = $.NSString.stringWithContentsOfFile(strPath)
+	var nsjira_report = $.NSString.stringWithContentsOfFileEncodingError(strPath,$.NSUTF8StringEncoding,null)
 	var jira_report = ObjC.unwrap(nsjira_report)
 	var report_json = JSON.parse(jira_report)
 


### PR DESCRIPTION
As JIRA uses UTF-8, but Apple mostly uses UTF-16, I added a conversion to support non ASCII languages (e.g. German)
