### PR TITLE
Fix jira gem require to match current name

### DIFF
--- a/lib/task_sources/jira/jira_to_jxa_app.rb
+++ b/lib/task_sources/jira/jira_to_jxa_app.rb
@@ -22,7 +22,7 @@ JIRA_MAX_RESULTS = 100
 require 'rubygems'
 require 'getoptlong'
 require 'yaml'
-require 'jira'
+require 'jira-ruby'
 require 'json'
 require 'tempfile'
 require File.join(File.dirname(__FILE__), '../../config_store')


### PR DESCRIPTION
Super useful little tool. Thanks!

I noticed while getting setup today that a gem name-change for jira broke `jira_to_jxa_app.rb`. This patch fixes that.